### PR TITLE
Diagnostics update

### DIFF
--- a/dingo_base/config/diagnostic_analyzers_common.yaml
+++ b/dingo_base/config/diagnostic_analyzers_common.yaml
@@ -14,8 +14,7 @@ analyzers:
           'dingo_node: User voltage supplies',
           'dingo_node: Current consumption',
           'dingo_node: Power consumption' ,
-          'dingo_node: Temperature',
-          'dingo_node: Wi-Fi connected']
+          'dingo_node: Temperature']
       sensors:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Sensor Topics

--- a/dingo_base/config/diagnostic_analyzers_common.yaml
+++ b/dingo_base/config/diagnostic_analyzers_common.yaml
@@ -14,7 +14,8 @@ analyzers:
           'dingo_node: User voltage supplies',
           'dingo_node: Current consumption',
           'dingo_node: Power consumption' ,
-          'dingo_node: Temperature' ]
+          'dingo_node: Temperature',
+          'dingo_node: Wi-Fi connected']
       sensors:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Sensor Topics

--- a/dingo_base/config/diagnostic_analyzers_common.yaml
+++ b/dingo_base/config/diagnostic_analyzers_common.yaml
@@ -15,16 +15,6 @@ analyzers:
           'dingo_node: Current consumption',
           'dingo_node: Power consumption' ,
           'dingo_node: Temperature' ]
-      motors:
-        type: diagnostic_aggregator/GenericAnalyzer
-        path: Motors
-        remove_prefix: 'dingo_node'
-        timeout: 5.0
-        expected: [
-          'dingo_node: Puma motor driver on: Dingo-D left_wheel or Dingo-O rear_left_wheel with CAN ID (2)',
-          'dingo_node: Puma motor driver on: Dingo-D right_wheel or Dingo-O rear_right_wheel with CAN ID (3)',
-          'dingo_node: Puma motor driver on: Dingo-O front_right_wheel with CAN ID (4)',
-          'dingo_node: Puma motor driver on: Dingo-O front_left_wheel with CAN ID (5)']
       sensors:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Sensor Topics

--- a/dingo_base/config/diagnostic_analyzers_diff.yaml
+++ b/dingo_base/config/diagnostic_analyzers_diff.yaml
@@ -9,5 +9,5 @@ analyzers:
         remove_prefix: 'dingo_node'
         timeout: 5.0
         expected: [
-          'dingo_node: Puma motor driver on: Dingo-D left_wheel with CAN ID (2)',
-          'dingo_node: Puma motor driver on: Dingo-D right_wheel with CAN ID (3)']
+          'dingo_node: Puma motor driver on: left_wheel with CAN ID (2)',
+          'dingo_node: Puma motor driver on: right_wheel with CAN ID (3)']

--- a/dingo_base/config/diagnostic_analyzers_diff.yaml
+++ b/dingo_base/config/diagnostic_analyzers_diff.yaml
@@ -1,0 +1,13 @@
+analyzers:
+  dingo:
+    type: diagnostic_aggregator/AnalyzerGroup
+    path: Dingo Base
+    analyzers:
+      motors:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Motors
+        remove_prefix: 'dingo_node'
+        timeout: 5.0
+        expected: [
+          'dingo_node: Puma motor driver on: Dingo-D left_wheel with CAN ID (2)',
+          'dingo_node: Puma motor driver on: Dingo-D right_wheel with CAN ID (3)']

--- a/dingo_base/config/diagnostic_analyzers_omni.yaml
+++ b/dingo_base/config/diagnostic_analyzers_omni.yaml
@@ -11,5 +11,5 @@ analyzers:
         expected: [
           'dingo_node: Puma motor driver on: front_left_wheel with CAN ID (2)',
           'dingo_node: Puma motor driver on: front_right_wheel with CAN ID (3)',
-          'dingo_node: Puma motor driver on: rear_right_wheel with CAN ID (4)',
-          'dingo_node: Puma motor driver on: rear_left_wheel with CAN ID (5)']
+          'dingo_node: Puma motor driver on: rear_left_wheel with CAN ID (4)',
+          'dingo_node: Puma motor driver on: rear_right_wheel with CAN ID (5)']

--- a/dingo_base/config/diagnostic_analyzers_omni.yaml
+++ b/dingo_base/config/diagnostic_analyzers_omni.yaml
@@ -9,7 +9,7 @@ analyzers:
         remove_prefix: 'dingo_node'
         timeout: 5.0
         expected: [
-          'dingo_node: Puma motor driver on: rear_left_wheel with CAN ID (2)',
-          'dingo_node: Puma motor driver on: rear_right_wheel with CAN ID (3)',
-          'dingo_node: Puma motor driver on: front_right_wheel with CAN ID (4)',
-          'dingo_node: Puma motor driver on: front_left_wheel with CAN ID (5)']
+          'dingo_node: Puma motor driver on: front_left_wheel with CAN ID (2)',
+          'dingo_node: Puma motor driver on: front_right_wheel with CAN ID (3)',
+          'dingo_node: Puma motor driver on: rear_right_wheel with CAN ID (4)',
+          'dingo_node: Puma motor driver on: rear_left_wheel with CAN ID (5)']

--- a/dingo_base/config/diagnostic_analyzers_omni.yaml
+++ b/dingo_base/config/diagnostic_analyzers_omni.yaml
@@ -1,0 +1,15 @@
+analyzers:
+  dingo:
+    type: diagnostic_aggregator/AnalyzerGroup
+    path: Dingo Base
+    analyzers:
+      motors:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Motors
+        remove_prefix: 'dingo_node'
+        timeout: 5.0
+        expected: [
+          'dingo_node: Puma motor driver on: Dingo-O rear_left_wheel with CAN ID (2)',
+          'dingo_node: Puma motor driver on: Dingo-O rear_right_wheel with CAN ID (3)',
+          'dingo_node: Puma motor driver on: Dingo-O front_right_wheel with CAN ID (4)',
+          'dingo_node: Puma motor driver on: Dingo-O front_left_wheel with CAN ID (5)']

--- a/dingo_base/config/diagnostic_analyzers_omni.yaml
+++ b/dingo_base/config/diagnostic_analyzers_omni.yaml
@@ -9,7 +9,7 @@ analyzers:
         remove_prefix: 'dingo_node'
         timeout: 5.0
         expected: [
-          'dingo_node: Puma motor driver on: Dingo-O rear_left_wheel with CAN ID (2)',
-          'dingo_node: Puma motor driver on: Dingo-O rear_right_wheel with CAN ID (3)',
-          'dingo_node: Puma motor driver on: Dingo-O front_right_wheel with CAN ID (4)',
-          'dingo_node: Puma motor driver on: Dingo-O front_left_wheel with CAN ID (5)']
+          'dingo_node: Puma motor driver on: rear_left_wheel with CAN ID (2)',
+          'dingo_node: Puma motor driver on: rear_right_wheel with CAN ID (3)',
+          'dingo_node: Puma motor driver on: front_right_wheel with CAN ID (4)',
+          'dingo_node: Puma motor driver on: front_left_wheel with CAN ID (5)']

--- a/dingo_base/include/dingo_base/dingo_diagnostic_updater.h
+++ b/dingo_base/include/dingo_base/dingo_diagnostic_updater.h
@@ -37,6 +37,7 @@
 
 #include "ros/ros.h"
 #include "std_msgs/Bool.h"
+#include "sensor_msgs/BatteryState.h"
 #include "sensor_msgs/Imu.h"
 #include "diagnostic_updater/diagnostic_updater.h"
 #include "diagnostic_updater/publisher.h"
@@ -86,6 +87,11 @@ public:
    */
   void statusCallback(const dingo_msgs::Status::ConstPtr& status);
 
+  /** Callback that is run when a battery state message is received
+   *  @param[in] battery_state Contents of battery state message
+   */
+  void batteryStateCallback(const sensor_msgs::BatteryState::ConstPtr& battery_state);
+
   /** Callback that is run when an IMU message is received
    *  @param[in] msg Contents of IMU message
    */
@@ -103,8 +109,14 @@ private:
   /** Used to subscribe for MCU status messages */
   ros::Subscriber status_sub_;
 
+  /** Used to subscribe for battery state messages */
+  ros::Subscriber battery_state_sub_;
+
   /** Last MCU status message */
   dingo_msgs::Status::ConstPtr last_status_;
+
+  /** Last battery state message */
+  sensor_msgs::BatteryState last_battery_state_;
 
   /** Frequency, in Hz, at which IMU updates are expected */
   double expected_imu_frequency_;

--- a/dingo_base/include/dingo_base/dingo_lighting.h
+++ b/dingo_base/include/dingo_base/dingo_lighting.h
@@ -61,6 +61,7 @@ public:
     Idle = 0,
     Driving,
     LowBattery,
+    OverVolt,
     NeedsReset,
     Fault,
     Stopped
@@ -135,6 +136,7 @@ private:
     LightsPatterns fault;
     LightsPatterns reset;
     LightsPatterns low_battery;
+    LightsPatterns over_volt;
     LightsPatterns driving;
     LightsPatterns idle;
   }

--- a/dingo_base/include/dingo_base/dingo_lighting.h
+++ b/dingo_base/include/dingo_base/dingo_lighting.h
@@ -40,6 +40,7 @@
 #include "geometry_msgs/Twist.h"
 #include "dingo_msgs/Lights.h"
 #include "dingo_msgs/Status.h"
+#include "sensor_msgs/BatteryState.h"
 #include "puma_motor_msgs/MultiStatus.h"
 
 namespace dingo_base
@@ -61,7 +62,6 @@ public:
     Idle = 0,
     Driving,
     LowBattery,
-    OverVolt,
     NeedsReset,
     Fault,
     Stopped
@@ -86,6 +86,9 @@ private:
   /** Used to subscribe to MCU status */
   ros::Subscriber mcu_status_sub_;
 
+  /** Used to subscrube to battery state */
+  ros::Subscriber battery_state_sub_;
+
   /** Used to subscribe to Puma motor controller status */
   ros::Subscriber puma_status_sub_;
 
@@ -97,6 +100,9 @@ private:
 
   /** The last received MCU status message */
   dingo_msgs::Status mcu_status_msg_;
+
+  /** The last received battery state message */
+  sensor_msgs::BatteryState battery_state_msg_;
 
   /** The last received velocity command */
   geometry_msgs::Twist cmd_vel_msg_;
@@ -136,7 +142,6 @@ private:
     LightsPatterns fault;
     LightsPatterns reset;
     LightsPatterns low_battery;
-    LightsPatterns over_volt;
     LightsPatterns driving;
     LightsPatterns idle;
   }
@@ -170,6 +175,11 @@ private:
    *  @param[in] status_msg The status message to be stored
    */
   void mcuStatusCallback(const dingo_msgs::Status::ConstPtr& status_msg);
+
+  /** Called when a battery state message is received, for state updates.
+   *  @param[in] battery_msg The battery-state message to be stored
+   */
+  void batteryStateCallback(const sensor_msgs::BatteryState::ConstPtr& battery_msg);
 
   /** Called when a velocity command is received, for state updates.
    *  @param[in] msg The velocity command to be stored

--- a/dingo_base/include/dingo_base/dingo_power_levels.h
+++ b/dingo_base/include/dingo_base/dingo_power_levels.h
@@ -36,20 +36,20 @@
 /**
  * Container for defining voltage & amperage warning levels for the Dingo-D and Dingo-O
  */
-class dingo_power {
+class dingo_power
+{
 public:
-
   // battery voltage warning levels
   static constexpr float VOLTAGE_ABSENT                =  1.0;
 
   // Lithium battery warning levels
-  // TODO (civerachb) -- All lithium battery-related code is currently untested, as the hardware to test it on
+  // TODO(civerachb) -- All lithium battery-related code is currently untested, as the hardware to test it on
   // doesn't exist yet!  We'll make any necessary changes to lithium battery support at a later date
   static constexpr float BATTERY_LITHIUM_OVER_VOLT     = 16.9;
   static constexpr float BATTERY_LITHIUM_LOW_VOLT      = 12.0;
   static constexpr float BATTERY_LITHIUM_CRITICAL_VOLT = 11.2;
-  static constexpr float BATTERY_LITHIUM_LOW_PERCENT   =  0.10;    // 0-1 TODO (civerachb) -- test this out on an actual Li battery & adjust
-  static constexpr float BATTERY_LITHIUM_CRITICAL_PERCENT = 0.05;  // 0-1 TODO (civerachb) -- test this out on an actual Li battery & adjust
+  static constexpr float BATTERY_LITHIUM_LOW_PERCENT   =  0.10;    // 0-1 TODO(civerachb) -- test this out on an actual Li battery & adjust
+  static constexpr float BATTERY_LITHIUM_CRITICAL_PERCENT = 0.05;  // 0-1 TODO(civerachb) -- test this out on an actual Li battery & adjust
 
   // SLA battery warning levels
   static constexpr float BATTERY_SLA_OVER_VOLT         = 13.6;
@@ -68,7 +68,7 @@ public:
   static constexpr float CURRENT_DRAW_REMINDER         =  8.0;
 
   // temperature warnings for PCB & MCU
-  static constexpr float TEMPERATURE_CRITICAL          =100.0;
-  static constexpr float TEMPERATURE_WARNING           = 60.0;
+  static constexpr float TEMPERATURE_CRITICAL          = 100.0;
+  static constexpr float TEMPERATURE_WARNING           =  60.0;
 };
-#endif
+#endif  // DINGO_BASE_DINGO_POWER_LEVELS_H

--- a/dingo_base/include/dingo_base/dingo_power_levels.h
+++ b/dingo_base/include/dingo_base/dingo_power_levels.h
@@ -46,6 +46,8 @@ public:
   static constexpr float BATTERY_LITHIUM_OVER_VOLT     = 16.9;
   static constexpr float BATTERY_LITHIUM_LOW_VOLT      = 12.0;
   static constexpr float BATTERY_LITHIUM_CRITICAL_VOLT = 11.2;
+  static constexpr float BATTERY_LITHIUM_LOW_PERCENT   =  0.10;    // 0-1 TODO (civerachb) -- test this out on an actual Li battery & adjust
+  static constexpr float BATTERY_LITHIUM_CRITICAL_PERCENT = 0.05;  // 0-1 TODO (civerachb) -- test this out on an actual Li battery & adjust
 
   // SLA battery warning levels
   static constexpr float BATTERY_SLA_OVER_VOLT         = 13.6;

--- a/dingo_base/include/dingo_base/dingo_power_levels.h
+++ b/dingo_base/include/dingo_base/dingo_power_levels.h
@@ -48,7 +48,7 @@ public:
   static constexpr float BATTERY_LITHIUM_OVER_VOLT     = 16.9;
   static constexpr float BATTERY_LITHIUM_LOW_VOLT      = 12.0;
   static constexpr float BATTERY_LITHIUM_CRITICAL_VOLT = 11.2;
-  static constexpr float BATTERY_LITHIUM_LOW_PERCENT   =  0.10;    // 0-1 TODO(civerachb) -- test this out on an actual Li battery & adjust
+  static constexpr float BATTERY_LITHIUM_LOW_PERCENT   =  0.20;    // 0-1 TODO(civerachb) -- test this out on an actual Li battery & adjust
   static constexpr float BATTERY_LITHIUM_CRITICAL_PERCENT = 0.05;  // 0-1 TODO(civerachb) -- test this out on an actual Li battery & adjust
 
   // SLA battery warning levels

--- a/dingo_base/include/dingo_base/dingo_power_levels.h
+++ b/dingo_base/include/dingo_base/dingo_power_levels.h
@@ -49,7 +49,7 @@ public:
   static constexpr float BATTERY_LITHIUM_LOW_VOLT      = 12.0;
   static constexpr float BATTERY_LITHIUM_CRITICAL_VOLT = 11.2;
   static constexpr float BATTERY_LITHIUM_LOW_PERCENT   =  0.20;    // 0-1 TODO(civerachb) -- test this out on an actual Li battery & adjust
-  static constexpr float BATTERY_LITHIUM_CRITICAL_PERCENT = 0.05;  // 0-1 TODO(civerachb) -- test this out on an actual Li battery & adjust
+  static constexpr float BATTERY_LITHIUM_CRITICAL_PERCENT = 0.10;  // 0-1 TODO(civerachb) -- test this out on an actual Li battery & adjust
 
   // SLA battery warning levels
   static constexpr float BATTERY_SLA_OVER_VOLT         = 13.6;

--- a/dingo_base/include/dingo_base/dingo_power_levels.h
+++ b/dingo_base/include/dingo_base/dingo_power_levels.h
@@ -43,6 +43,8 @@ public:
   static constexpr float VOLTAGE_ABSENT                =  1.0;
 
   // Lithium battery warning levels
+  // TODO (civerachb) -- All lithium battery-related code is currently untested, as the hardware to test it on
+  // doesn't exist yet!  We'll make any necessary changes to lithium battery support at a later date
   static constexpr float BATTERY_LITHIUM_OVER_VOLT     = 16.9;
   static constexpr float BATTERY_LITHIUM_LOW_VOLT      = 12.0;
   static constexpr float BATTERY_LITHIUM_CRITICAL_VOLT = 11.2;

--- a/dingo_base/include/dingo_base/dingo_power_levels.h
+++ b/dingo_base/include/dingo_base/dingo_power_levels.h
@@ -1,0 +1,70 @@
+/**
+ *  \file       dingo_hardware.h
+ *  \brief      Class representing Dingo hardware
+ *  \copyright  Copyright (c) 2020, Clearpath Robotics, Inc.
+ *
+ * Software License Agreement (BSD)
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Clearpath Robotics, Inc. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Please send comments, questions, or patches to code@clearpathrobotics.com
+ */
+
+#ifndef DINGO_BASE_DINGO_POWER_LEVELS_H
+#define DINGO_BASE_DINGO_POWER_LEVELS_H
+
+/**
+ * Container for defining voltage & amperage warning levels for the Dingo-D and Dingo-O
+ */
+class dingo_power {
+public:
+
+  // battery voltage warning levels
+  static constexpr float VOLTAGE_ABSENT                =  1.0;
+
+  // Lithium battery warning levels
+  static constexpr float BATTERY_LITHIUM_OVER_VOLT     = 16.9;
+  static constexpr float BATTERY_LITHIUM_LOW_VOLT      = 12.0;
+  static constexpr float BATTERY_LITHIUM_CRITICAL_VOLT = 11.2;
+
+  // SLA battery warning levels
+  static constexpr float BATTERY_SLA_OVER_VOLT         = 13.6;
+  static constexpr float BATTERY_SLA_LOW_VOLT          = 12.0;
+  static constexpr float BATTERY_SLA_CRITICAL_VOLT     = 11.8;
+
+  // user-device power supply voltage warning levels
+  static constexpr float USER_VOLT_12_LOW              = 11.0;
+  static constexpr float USER_VOLT_5_LOW               =  4.0;
+  static constexpr float USER_VOLT_12_HIGH             = 12.5;
+  static constexpr float USER_VOLT_5_HIGH              =  5.5;
+
+  // amperage warning levels
+  static constexpr float CURRENT_DRAW_CRITICAL         = 28.0;
+  static constexpr float CURRENT_DRAW_WARNING          = 18.0;
+  static constexpr float CURRENT_DRAW_REMINDER         =  8.0;
+
+  // temperature warnings for PCB & MCU
+  static constexpr float TEMPERATURE_CRITICAL          =100.0;
+  static constexpr float TEMPERATURE_WARNING           = 60.0;
+};
+#endif

--- a/dingo_base/launch/base.launch
+++ b/dingo_base/launch/base.launch
@@ -31,13 +31,13 @@
   <group if="$(optenv DINGO_OMNI 0)">
     <node pkg="diagnostic_aggregator" type="aggregator_node" name="diagnostic_aggregator">
       <rosparam command="load" file="$(find dingo_base)/config/diagnostic_analyzers_common.yaml" />
-      <rosparam command="load" file="$(find dingo_base)/config/diagnostic_analyzers_diff.yaml" />
+      <rosparam command="load" file="$(find dingo_base)/config/diagnostic_analyzers_omni.yaml" />
     </node>
   </group>
   <group unless="$(optenv DINGO_OMNI 0)">
     <node pkg="diagnostic_aggregator" type="aggregator_node" name="diagnostic_aggregator">
       <rosparam command="load" file="$(find dingo_base)/config/diagnostic_analyzers_common.yaml" />
-      <rosparam command="load" file="$(find dingo_base)/config/diagnostic_analyzers_omni.yaml" />
+      <rosparam command="load" file="$(find dingo_base)/config/diagnostic_analyzers_diff.yaml" />
     </node>
   </group>
 </launch>

--- a/dingo_base/launch/base.launch
+++ b/dingo_base/launch/base.launch
@@ -28,7 +28,16 @@
   <include file="$(find dingo_control)/launch/teleop.launch" />
 
   <!-- Diagnostic Aggregator for robot monitor usage -->
-  <node pkg="diagnostic_aggregator" type="aggregator_node" name="diagnostic_aggregator">
-    <rosparam command="load" file="$(find dingo_base)/config/diagnostic_analyzers.yaml" />
-  </node>
+  <group if="$(optenv DINGO_OMNI 0)">
+    <node pkg="diagnostic_aggregator" type="aggregator_node" name="diagnostic_aggregator">
+      <rosparam command="load" file="$(find dingo_base)/config/diagnostic_analyzers_common.yaml" />
+      <rosparam command="load" file="$(find dingo_base)/config/diagnostic_analyzers_diff.yaml" />
+    </node>
+  </group>
+  <group unless="$(optenv DINGO_OMNI 0)">
+    <node pkg="diagnostic_aggregator" type="aggregator_node" name="diagnostic_aggregator">
+      <rosparam command="load" file="$(find dingo_base)/config/diagnostic_analyzers_common.yaml" />
+      <rosparam command="load" file="$(find dingo_base)/config/diagnostic_analyzers_omni.yaml" />
+    </node>
+  </group>
 </launch>

--- a/dingo_base/src/dingo_diagnostic_updater.cpp
+++ b/dingo_base/src/dingo_diagnostic_updater.cpp
@@ -59,7 +59,7 @@ DingoDiagnosticUpdater::DingoDiagnosticUpdater()
   status_sub_ = nh_.subscribe("mcu/status", 5, &DingoDiagnosticUpdater::statusCallback, this);
 
   // record the battery state
-  battery_state_sub_ = nh_.subscribe("/battery/state", 1, &DingoDiagnosticUpdater::batteryStateCallback, this);
+  battery_state_sub_ = nh_.subscribe("battery/state", 1, &DingoDiagnosticUpdater::batteryStateCallback, this);
 
   // These message frequencies are reported on separately.
   ros::param::param("~expected_imu_frequency", expected_imu_frequency_, 50.0);

--- a/dingo_base/src/dingo_diagnostic_updater.cpp
+++ b/dingo_base/src/dingo_diagnostic_updater.cpp
@@ -150,16 +150,19 @@ void DingoDiagnosticUpdater::voltageDiagnostics(diagnostic_updater::DiagnosticSt
   stat.add("12V Supply (V)", last_status_->measured_12v);
   stat.add("5V Supply (V)", last_status_->measured_5v);
 
-  if (last_status_->measured_12v > dingo_power::USER_VOLT_12_HIGH || last_status_->measured_5v > dingo_power::USER_VOLT_5_HIGH)
+  if (last_status_->measured_12v > dingo_power::USER_VOLT_12_HIGH ||
+      last_status_->measured_5v > dingo_power::USER_VOLT_5_HIGH)
   {
     stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR,
         "User supply overvoltage. Accessories may be damaged.");
   }
-  else if (last_status_->measured_12v < dingo_power::VOLTAGE_ABSENT || last_status_->measured_5v < dingo_power::VOLTAGE_ABSENT)
+  else if (last_status_->measured_12v < dingo_power::VOLTAGE_ABSENT ||
+           last_status_->measured_5v < dingo_power::VOLTAGE_ABSENT)
   {
     stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR, "User supplies absent. Check tray fuses.");
   }
-  else if (last_status_->measured_12v < dingo_power::USER_VOLT_12_LOW || last_status_->measured_5v < dingo_power::USER_VOLT_5_LOW)
+  else if (last_status_->measured_12v < dingo_power::USER_VOLT_12_LOW ||
+           last_status_->measured_5v < dingo_power::USER_VOLT_5_LOW)
   {
     stat.summary(diagnostic_msgs::DiagnosticStatus::WARN, "Voltage supplies undervoltage. Check loading levels.");
   }

--- a/dingo_base/src/dingo_diagnostic_updater.cpp
+++ b/dingo_base/src/dingo_diagnostic_updater.cpp
@@ -59,8 +59,7 @@ DingoDiagnosticUpdater::DingoDiagnosticUpdater()
   status_sub_ = nh_.subscribe("mcu/status", 5, &DingoDiagnosticUpdater::statusCallback, this);
 
   // record the battery state
-  // TODO (civerachb) -- check the topic once we have access to an MCU for validation
-  battery_state_sub_ = nh_.subscribe("mcu/battery_state", 1, &DingoDiagnosticUpdater::batteryStateCallback, this);
+  battery_state_sub_ = nh_.subscribe("/battery/state", 1, &DingoDiagnosticUpdater::batteryStateCallback, this);
 
   // These message frequencies are reported on separately.
   ros::param::param("~expected_imu_frequency", expected_imu_frequency_, 50.0);

--- a/dingo_base/src/dingo_diagnostic_updater.cpp
+++ b/dingo_base/src/dingo_diagnostic_updater.cpp
@@ -40,23 +40,23 @@
 #include "dingo_base/dingo_diagnostic_updater.h"
 
 // battery & user voltage warning levels
-#define VOLTAGE_ABSENT           1.0
-#define BATTERY_OVER_VOLT       16.8   // TODO(tbaltovski): different for SLA vs Lithium
-#define BATTERY_CRITICAL_VOLT   11.2   // TODO(tbaltovski): different for SLA vs Lithium
-#define BATTERY_LOW_VOLT        12.0   // TODO(tbaltovski): different for SLA vs Lithium
-#define USER_VOLT_12_LOW        11.0
-#define USER_VOLT_5_LOW          4.0
-#define USER_VOLT_12_HIGH       12.5
-#define USER_VOLT_5_HIGH         5.5
+static constexpr float VOLTAGE_ABSENT        =  1.0;
+static constexpr float BATTERY_OVER_VOLT     = 16.8;   // TODO(tbaltovski): different for SLA vs Lithium
+static constexpr float BATTERY_CRITICAL_VOLT = 11.2;   // TODO(tbaltovski): different for SLA vs Lithium
+static constexpr float BATTERY_LOW_VOLT      = 12.0;   // TODO(tbaltovski): different for SLA vs Lithium
+static constexpr float USER_VOLT_12_LOW      = 11.0;
+static constexpr float USER_VOLT_5_LOW       =  4.0;
+static constexpr float USER_VOLT_12_HIGH     = 12.5;
+static constexpr float USER_VOLT_5_HIGH      =  5.5;
 
 // amperage warning levels
-#define CURRENT_DRAW_CRITICAL   32.0   // TODO(tbaltovski): check current thresholds
-#define CURRENT_DRAW_WARNING    20.0   // TODO(tbaltovski): check current thresholds
-#define CURRENT_DRAW_REMINDER   10.0   // TODO(tbaltovski): check current thresholds
+static constexpr float CURRENT_DRAW_CRITICAL = 32.0;   // TODO(tbaltovski): check current thresholds
+static constexpr float CURRENT_DRAW_WARNING  = 20.0;   // TODO(tbaltovski): check current thresholds
+static constexpr float CURRENT_DRAW_REMINDER = 10.0;   // TODO(tbaltovski): check current thresholds
 
 // temperature warnings for PCB & MCU
-#define TEMPERATURE_CRITICAL   100.0
-#define TEMPERATURE_WARNING     60.0
+static constexpr float TEMPERATURE_CRITICAL  =100.0;
+static constexpr float TEMPERATURE_WARNING   = 60.0;
 
 namespace dingo_base
 {

--- a/dingo_base/src/dingo_lighting.cpp
+++ b/dingo_base/src/dingo_lighting.cpp
@@ -72,7 +72,7 @@ DingoLighting::DingoLighting(ros::NodeHandle* nh) :
 
   user_cmds_sub_ = nh_->subscribe("cmd_lights", 1, &DingoLighting::userCmdCallback, this);
   mcu_status_sub_ = nh_->subscribe("mcu/status", 1, &DingoLighting::mcuStatusCallback, this);
-  battery_state_sub_ = nh_->subscribe("/battery/state", 1, &DingoLighting::batteryStateCallback, this);
+  battery_state_sub_ = nh_->subscribe("battery/state", 1, &DingoLighting::batteryStateCallback, this);
   puma_status_sub_ = nh_->subscribe("status", 1, &DingoLighting::pumaStatusCallback, this);
   cmd_vel_sub_ = nh_->subscribe("cmd_vel", 1, &DingoLighting::cmdVelCallback, this);
 

--- a/dingo_base/src/dingo_lighting.cpp
+++ b/dingo_base/src/dingo_lighting.cpp
@@ -72,7 +72,7 @@ DingoLighting::DingoLighting(ros::NodeHandle* nh) :
 
   user_cmds_sub_ = nh_->subscribe("cmd_lights", 1, &DingoLighting::userCmdCallback, this);
   mcu_status_sub_ = nh_->subscribe("mcu/status", 1, &DingoLighting::mcuStatusCallback, this);
-  battery_state_sub_ = nh_->subscribe("mcu/battery_state", 1, &DingoLighting::batteryStateCallback, this); // TODO (civerachb) -- check the topic once we have access to an MCU for validation
+  battery_state_sub_ = nh_->subscribe("/battery/state", 1, &DingoLighting::batteryStateCallback, this);
   puma_status_sub_ = nh_->subscribe("status", 1, &DingoLighting::pumaStatusCallback, this);
   cmd_vel_sub_ = nh_->subscribe("cmd_vel", 1, &DingoLighting::cmdVelCallback, this);
 

--- a/dingo_base/src/dingo_lighting.cpp
+++ b/dingo_base/src/dingo_lighting.cpp
@@ -203,22 +203,22 @@ void DingoLighting::updateState()
     state_ = State::Fault;
   }
   else if (battery_state_msg_.power_supply_technology == sensor_msgs::BatteryState::POWER_SUPPLY_TECHNOLOGY_UNKNOWN &&
-           mcu_status_msg_.measured_battery <= dingo_power::BATTERY_SLA_LOW_VOLT )          // SLA battery & voltage is low
+           mcu_status_msg_.measured_battery <= dingo_power::BATTERY_SLA_LOW_VOLT )  // SLA battery & voltage is low
   {
     state_ = State::LowBattery;
   }
   else if (battery_state_msg_.power_supply_technology == sensor_msgs::BatteryState::POWER_SUPPLY_TECHNOLOGY_UNKNOWN &&
-           mcu_status_msg_.measured_battery >= dingo_power::BATTERY_SLA_OVER_VOLT )         // SLA battery & voltage over-volting
+           mcu_status_msg_.measured_battery >= dingo_power::BATTERY_SLA_OVER_VOLT )  // SLA battery & voltage over-volt
   {
     state_ = State::Fault;
   }
   else if (battery_state_msg_.power_supply_technology != sensor_msgs::BatteryState::POWER_SUPPLY_TECHNOLOGY_UNKNOWN &&
-           battery_state_msg_.percentage <= dingo_power::BATTERY_LITHIUM_LOW_PERCENT )      // Li battery & remaining charge is low
+           battery_state_msg_.percentage <= dingo_power::BATTERY_LITHIUM_LOW_PERCENT )  // Li battery & charge is low
   {
     state_ = State::LowBattery;
   }
   else if (battery_state_msg_.power_supply_technology != sensor_msgs::BatteryState::POWER_SUPPLY_TECHNOLOGY_UNKNOWN &&
-           battery_state_msg_.voltage >= dingo_power::BATTERY_LITHIUM_OVER_VOLT )            // Li battery & voltage over-volting
+           battery_state_msg_.voltage >= dingo_power::BATTERY_LITHIUM_OVER_VOLT )  // Li battery & voltage over-volt
   {
     state_ = State::Fault;
   }


### PR DESCRIPTION
Keep common diagnostics configurations in one file, with Dingo-O and Dingo-D specific changes (e.g. CAN IDs for the wheels) in separate files loaded dynamically.

Refactor the diagnostic updater slightly to make voltage, temperature, and amperage warning levels easier to find & edit in future.  Put a simple message in the Power Consumption topic to suppress a perceived error in robot_monitor that flags no-message as an error.  (Placeholder message just says if the robot is on battery vs shore power.)

Current issues this PR does not resolve: /imu/data_raw appears to be publishing at 2x the proper rate; Lindy's user 12V supply appears to be broken, so I'm getting a consistent "check fuse" warning on that message.  Otherwise everything looks OK in my testing.